### PR TITLE
CI: Install cocotb-usb in conda

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ jobs:
         - git -C test-suite clone https://github.com/enjoy-digital/litex.git
         # We need to install those in virtualenv, as cocotb will use this instead of conda
         - pip install -r test-suite/conf/requirements.txt
-        - pip install -e test-suite/usb-test-suite-cocotb-usb/
         - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
         - bash miniconda.sh -b -p $HOME/miniconda
         - source "$HOME/miniconda/etc/profile.d/conda.sh"
@@ -29,6 +28,7 @@ jobs:
         - conda activate usb-test-suite-env
         # conda complains if it does not have the libs as well
         - pip install -r test-suite/conf/requirements.txt
+        - pip install -e test-suite/usb-test-suite-cocotb-usb/
         - cp test-suite/litex/litex_setup.py test-suite
         - ./test-suite/litex_setup.py init install --user
       script:


### PR DESCRIPTION
Fixes #15. With the new version of cocotb some changes were needed in test suite submodules, but they will be fetched automatically.