### PR TITLE
Burst support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,23 +33,23 @@ jobs:
         - ./test-suite/litex_setup.py init install --user
       script:
         - cd test-suite/usb-test-suite-testbenches
-        - make PYTHONPATH=../litex:../.. TARGET=$T TEST_SCRIPT=$S $OP $CDC && ! grep -q failure results.xml
+        - make PYTHONPATH=../litex:../.. TARGET=$T TEST_SCRIPT=$S $OP CDC=$CDC && ! grep -q failure results.xml
 
     - <<: *test_body
       env:
-        - T=valentyusb  S=test-enum        OP=sim
+        - T=valentyusb  S=test-enum        OP=sim    CDC=0
     - <<: *test_body
       env:
-        - T=valentyusb  S=test-w10enum     OP=sim
+        - T=valentyusb  S=test-w10enum     OP=sim    CDC=0
     - <<: *test_body
       env:
-        - T=valentyusb  S=test-clocks      OP=sim
+        - T=valentyusb  S=test-clocks      OP=sim    CDC=0
     - <<: *test_body
       env:
-        - T=valentyusb  S=test-macOSenum   OP=sim
+        - T=valentyusb  S=test-macOSenum   OP=sim    CDC=0
     - <<: *test_body
       env:
-        - T=valentyusb  S=test-valenty-cdc OP=sim
+        - T=valentyusb  S=test-valenty-cdc OP=sim    CDC=0
     - <<: *test_body
       env:
         - T=valentyusb  S=test-eptri       OP=sim    CDC=1

--- a/valentyusb/usbcore/cpu/dummyusb.py
+++ b/valentyusb/usbcore/cpu/dummyusb.py
@@ -11,6 +11,7 @@ from ..endpoint import EndpointType, EndpointResponse
 from ..pid import PID, PIDTypes
 from ..sm.transfer import UsbTransfer
 from .usbwishbonebridge import USBWishboneBridge
+from .usbwishboneburstbridge import USBWishboneBurstBridge
 
 class DummyUsb(Module, AutoDoc, ModuleDoc):
     """DummyUSB Self-Enumerating USB Controller

--- a/valentyusb/usbcore/cpu/dummyusb.py
+++ b/valentyusb/usbcore/cpu/dummyusb.py
@@ -227,10 +227,12 @@ class DummyUsb(Module, AutoDoc, ModuleDoc):
         ]
 
         # Wire up debug signals if required
+        data_phase = Signal()
         if debug:
             debug_bridge = USBWishboneBridge(usb_core, cdc=cdc, relax_timing=relax_timing)
             self.submodules.debug_bridge = debug_bridge
             self.comb += [
+                data_phase.eq(self.debug_bridge.data_phase),
                 debug_packet_detected.eq(~self.debug_bridge.n_debug_in_progress),
                 debug_sink_data.eq(self.debug_bridge.sink_data),
                 debug_sink_data_ready.eq(self.debug_bridge.sink_valid),
@@ -238,7 +240,7 @@ class DummyUsb(Module, AutoDoc, ModuleDoc):
             ]
 
         self.comb += [
-            usb_core.dtb.eq(1),
+            usb_core.dtb.eq(1 ^ data_phase),
             If(debug_packet_detected,
                 usb_core.sta.eq(0),
                 usb_core.arm.eq(debug_ack_response),

--- a/valentyusb/usbcore/cpu/usbwishbonebridge.py
+++ b/valentyusb/usbcore/cpu/usbwishbonebridge.py
@@ -176,6 +176,7 @@ class USBWishboneBridge(Module, AutoDoc):
         fsm = ResetInserter()(ClockDomainsRenamer("usb_12")(FSM(reset_state="IDLE")))
         self.submodules += fsm
         fsm.act("IDLE",
+            NextValue(not_first_byte, 0),
             NextValue(self.data_phase, 0),
             self.n_debug_in_progress.eq(1),
             If(usb_core.data_recv_put,

--- a/valentyusb/usbcore/cpu/usbwishbonebridge.py
+++ b/valentyusb/usbcore/cpu/usbwishbonebridge.py
@@ -249,7 +249,7 @@ class USBWishboneBridge(Module, AutoDoc):
                        byte_counter_ce.eq(1),
                     ),
                     burst_counter_ce.eq(1),
-                    If((burst_counter < 64) & ((burst_counter & 3) == 3),
+                    If((burst_counter <= 64) & ((burst_counter & 3) == 0) & (burst_counter != 0),
                        address_inc.eq(1),
                     ),
                     If(byte_counter == (length - 1) | (((byte_counter & 0x3F) == 0x3F) & not_first_byte),

--- a/valentyusb/usbcore/cpu/usbwishbonebridge.py
+++ b/valentyusb/usbcore/cpu/usbwishbonebridge.py
@@ -69,6 +69,8 @@ class USBWishboneBridge(Module, AutoDoc):
                 ]}
         """)
         # # #
+        self.data_phase = Signal()
+        self.comb += self.data_phase.eq(0)  # unused tiedown in this core; used in variants with burst support
 
         byte_counter = Signal(3, reset_less=True)
         byte_counter_reset = Signal()

--- a/valentyusb/usbcore/cpu/usbwishbonebridge.py
+++ b/valentyusb/usbcore/cpu/usbwishbonebridge.py
@@ -328,6 +328,7 @@ class USBWishboneBridge(Module, AutoDoc):
             # Keep sink_valid high during the packet, which indicates we have data
             # to send.  This also causes an "ACK" to be transmitted.
             If( ((byte_counter & 63) == 63) & ((byte_counter + 1) != length),
+                byte_counter_ce.eq(1),
                 self.sink_valid.eq(0), # signal to the host that it's time to switch phases
                 NextState("READ_DATA"),
                 send_to_wishbone.eq(1),

--- a/valentyusb/usbcore/cpu/usbwishbonebridge.py
+++ b/valentyusb/usbcore/cpu/usbwishbonebridge.py
@@ -321,8 +321,9 @@ class USBWishboneBridge(Module, AutoDoc):
         fsm.act("SEND_DATA_BURST_WAIT",
             self.n_debug_in_progress.eq(0),
             self.sink_valid.eq(usb_core.endp == 0),
-            send_to_wishbone.eq(1),
-            NextState("SEND_DATA"),
+            If(reply_from_wishbone,
+               NextState("SEND_DATA"),
+            )
         )
         self.comb += \
             chooser(rd_data, byte_counter[0:2], self.sink_data, n=4, reverse=False)
@@ -338,6 +339,7 @@ class USBWishboneBridge(Module, AutoDoc):
                 NextValue(not_first_byte, 1),
                 byte_counter_ce.eq(1),
                 If( ((byte_counter & 3) == 3) & ((byte_counter + 1) != length),
+                    send_to_wishbone.eq(1),
                     address_inc.eq(1),
                     NextState("SEND_DATA_BURST_WAIT"),
                 )

--- a/valentyusb/usbcore/cpu/usbwishboneburstbridge.py
+++ b/valentyusb/usbcore/cpu/usbwishboneburstbridge.py
@@ -1,0 +1,470 @@
+from migen import *
+
+from migen.genlib.misc import chooser, WaitTimer
+from migen.genlib.record import Record
+from migen.genlib.fsm import FSM, NextState
+from migen.genlib.fifo import AsyncFIFOBuffered
+from migen.genlib.cdc import PulseSynchronizer, MultiReg, BusSynchronizer
+from litex.soc.interconnect import stream
+
+from litex.soc.interconnect import wishbone
+from litex.soc.interconnect import stream
+
+from litex.soc.integration.doc import ModuleDoc, AutoDoc
+
+from ..pid import PID, PIDTypes
+
+class USBWishboneBurstBridge(Module, AutoDoc):
+
+    def __init__(self, usb_core, magic_packet=0x43):
+        self.wishbone = wishbone.Interface()
+
+        self.background = ModuleDoc(title="USB Wishbone Bridge", body="""
+            This bridge provides a transparent bridge to the target device's Wishbone bus over USB.
+            It can operate without interfering with the device's USB stack.  It is simple enough to
+            be able to work even if the USB stack is not enumerated, though the host may not cooperate.""")
+
+        self.protocol = ModuleDoc(title="USB Wishbone Debug Protocol", body="""
+        The protocol transfers four bytes a time in big-endian (i.e. USB) order.  It uses SETUP packets
+        with the special type (0x43) as an `attention` word.  This is then followed by an ``OUT`` packet.
+
+            .. wavedrom::
+                :caption: Write to Wishbone
+
+                { "signal": [
+                    ["Request",
+                        {  "name": 'data',        "wave": 'x222...22x', "data": '0x43 0x00 [ADDRESS] 0x04 0x00'   },
+                        {  "name": 'data bits',   "wave": 'xxx2222xxx', "data": '7:0 15:8 23:16 31:24'},
+                        {  "name": 'usb meaning', "wave": 'x222.2.2.x', "data": 'bReq bTyp wValue wIndex wLength' },
+                        {  "name": 'usb byte',    "wave": 'x22222222x', "data": '1 2 3 4 5 6 7 8'                 }
+                    ],
+                    {},
+                    ["Payload",
+                        {  "name": 'data',        "wave": 'x3...x', "data": '[DATA]'},
+                        {  "name": 'data bits',   "wave": 'x3333x', "data": '7:0 15:8 23:16 31:24'},
+                        {  "name": 'usb meaning', "wave": 'x3...x', "data": 'OUT'  },
+                        {  "name": 'usb byte',    "wave": 'x3333x', "data": '1 2 3 4'}
+                    ]
+                ]}
+
+        To read data from the device, set the top bit of the `bRequestType`, followed by an ``IN`` packet.
+
+            .. wavedrom::
+                :caption: Read from Wishbone
+
+                { "signal": [
+                    ['Request',
+                        {  "name": 'data',        "wave": 'x222...22x', "data": '0xC3 0x00 [ADDRESS] 0x04 0x00'   },
+                        {  "name": 'data bits',   "wave": 'xxx2222xxx', "data": '7:0 15:8 23:16 31:24'},
+                        {  "name": 'usb meaning', "wave": 'x222.2.2.x', "data": 'bReq bTyp wValue wIndex wLength' },
+                        {  "name": 'usb byte',    "wave": 'x22222222x', "data": '1 2 3 4 5 6 7 8'                 }
+                    ],
+                    {},
+                    ["Payload",
+                        {  "name": 'data',        "wave": 'x5...x', "data": '[DATA]'},
+                        {  "name": 'data bits',   "wave": 'x5555x', "data": '7:0 15:8 23:16 31:24'},
+                        {  "name": 'usb meaning', "wave": 'x5...x', "data": 'IN'  },
+                        {  "name": 'usb byte',    "wave": 'x5555x', "data": '1 2 3 4'}
+                    ]
+                ]}
+        """)
+        # # #
+
+        # Unlike the UART or Ethernet bridges, we explicitly only
+        # support two commands: reading and writing.  This gets
+        # integrated into the USB protocol, so it's not really a
+        # state.  1 is "USB Device to Host", and is therefore a "read",
+        # while 0 is "USB Host to Device", and is therefore a "write".
+        self.cmd = cmd = Signal(1, reset_less=True)
+        cmd_ce = Signal()
+
+        self.data_phase = Signal()
+
+        # Instead of self.source and self.sink, we let the wrapping
+        # module handle packing and unpacking the data.
+        self.sink_data = Signal(8)
+
+        # True when the "sink" value has data
+        self.sink_valid = Signal()
+
+        self.send_ack = Signal()
+
+        # Indicates whether a "debug" packet is currently being processed
+        self.n_debug_in_progress = Signal(reset=1)
+
+
+        byte_counter = Signal(17, reset_less=True) # up to 64k + 1
+        byte_counter_reset = Signal()
+        byte_counter_ce = Signal()
+        self.sync.usb_12 += \
+            If(byte_counter_reset,
+                byte_counter.eq(0)
+            ).Elif(byte_counter_ce,
+                byte_counter.eq(byte_counter + 1)
+            )
+
+        burst_counter = Signal(7, reset_less=True) # up to 64 + 1
+        burst_counter_ce = Signal()
+        self.sync.usb_12 += \
+            If(usb_core.start,
+                burst_counter.eq(0)
+            ).Elif(burst_counter_ce,
+                burst_counter.eq(burst_counter + 1)
+            )
+
+        self.address = address = Signal(32, reset_less=True)
+        address_ce = Signal()
+        address_inc = Signal()
+
+        self.length = length = Signal(16, reset_less=True)
+        length_ce = Signal()
+
+        self.data = data = Signal(32, reset_less=True)
+        self.rd_data = rd_data = Signal(32, reset_less=True)
+        rx_data_ce = Signal()
+
+        # wishbone_response = Signal(32, reset_less=True)
+        self.sync.usb_12 += [
+            If(cmd_ce, cmd.eq(usb_core.data_recv_payload[7:8])),
+            If(address_ce,
+                address.eq(Cat(address[8:32], usb_core.data_recv_payload)),
+            ),#.Elif(address_inc,
+            #    address.eq(address + 4),
+            #),
+            If(length_ce, length.eq(Cat(length[8:16],usb_core.data_recv_payload))),
+            If(rx_data_ce,
+                data.eq(Cat(data[8:32], usb_core.data_recv_payload))
+            )
+        ]
+
+        # Add a bridge to allow this module (in the usb_12 domain) to access
+        # the main Wishbone bridge (potentially in some other domain).
+        # Ensure this bridge is placed in the "sys" domain.
+        send_to_wishbone = Signal()
+        reply_from_wishbone = Signal()
+        transfer_active = Signal()
+
+        self.submodules.wb_cd_bridge = wb_cd_bridge = FSM(reset_state="IDLE")
+        self.submodules.usb_to_wb = usb_to_wb = PulseSynchronizer("usb_12", "sys")
+        self.submodules.wb_to_uwb = wb_to_usb = PulseSynchronizer("sys", "usb_12")
+        self.comb += [
+           usb_to_wb.i.eq(send_to_wishbone),
+           reply_from_wishbone.eq(wb_to_usb.o),
+        ]
+        self.cmd_sys = cmd_sys = Signal()
+        self.specials += MultiReg(cmd, cmd_sys)
+        prefetch_go = Signal()
+        prefetch_go_sys = Signal()
+        self.specials += MultiReg(prefetch_go, prefetch_go_sys)
+
+        ### cross clock domains using a FIFO. also makes burst access possible.
+        self.specials.write_fifo = ClockDomainsRenamer({"write": "usb_12", "read": "sys"})(AsyncFIFOBuffered(32, 64))
+        self.specials.read_fifo = ClockDomainsRenamer({"write": "sys", "read": "usb_12"})(AsyncFIFOBuffered(32, 64))
+        self.comb += [
+            # clk12 domain
+            self.write_fifo.din.eq(data),      # data coming from USB interface
+            rd_data.eq(self.read_fifo.dout),  # data going to USB interface
+            # sys domain
+            self.read_fifo.din.eq(self.wishbone.dat_r),
+            self.wishbone.dat_w.eq(self.write_fifo.dout),
+        ]
+
+        self.address_wb = Signal(32)
+        self.submodules.address_synchronizer = BusSynchronizer(32, "usb_12", "sys")
+        self.comb += self.address_synchronizer.i.eq(self.address),
+        self.submodules.length_synchronizer = BusSynchronizer(16, "usb_12", "sys")
+        self.length_sys = Signal(16)
+        self.comb += [self.length_synchronizer.i.eq(self.length), self.length_sys.eq(self.length_synchronizer.o)]
+
+
+        self.burstcount = Signal(16)
+        wbmanager = FSM(reset_state="IDLE") # in sys domain
+        self.submodules += wbmanager
+        wbmanager.act("IDLE",
+            NextValue(self.address_wb, self.address_synchronizer.o),
+            NextValue(self.burstcount, 0),
+            If(prefetch_go_sys & cmd_sys,  # 0xC3 (bit set) == read
+                NextState("READER")
+            ).Elif(prefetch_go_sys & ~cmd_sys,
+                NextState("WRITER")
+            )
+        )
+        wbmanager.act("READER",
+            If( (self.burstcount < self.length_sys) & (self.read_fifo.writable),
+                self.wishbone.stb.eq(1),
+                self.wishbone.we.eq(0),
+                self.wishbone.cyc.eq(1),
+                self.wishbone.cti.eq(0),  # classic cycle
+                self.wishbone.adr.eq( (self.address_wb + self.burstcount)[2:] ),
+                NextState("READER_WAIT")
+            ).Else(
+                NextState("WAIT_DONE")
+            )
+        )
+        wbmanager.act("READER_WAIT",
+            If(self.wishbone.ack | self.wishbone.err,
+                self.read_fifo.we.eq(1),
+                NextValue(self.burstcount, self.burstcount + 4),
+                NextState("READER"),
+            )
+        )
+        wbmanager.act("WRITER",
+            If(self.burstcount < self.length_sys,
+                If(self.write_fifo.readable,
+                    self.wishbone.stb.eq(1),
+                    self.wishbone.we.eq(1),
+                    self.wishbone.cyc.eq(1),
+                    self.wishbone.cti.eq(0),  # classic cycle
+                    self.wishbone.adr.eq( (self.address_wb + self.burstcount)[2:] ),
+                    self.write_fifo.re.eq(1),
+                    NextValue(self.burstcount, self.burstcount + 4),
+                    NextState("WRITER_WAIT"),
+                )
+            ).Else(
+                NextState("WAIT_DONE")
+            )
+        )
+        wbmanager.act("WRITER_WAIT",
+            If(self.wishbone.ack | self.wishbone.err,
+                NextState("WRITER")
+            )
+        )
+        wbmanager.act("WAIT_DONE",
+            If(~prefetch_go_sys,
+                NextState("IDLE")
+            )
+        )
+        self.comb += self.wishbone.sel.eq(2 ** len(self.wishbone.sel) - 1)
+
+
+
+        not_first_byte=Signal()
+        
+        fsm = ResetInserter()(ClockDomainsRenamer("usb_12")(FSM(reset_state="IDLE")))
+        self.submodules += fsm
+        fsm.act("IDLE",
+            NextValue(prefetch_go, 0),
+            NextValue(not_first_byte, 0),
+            NextValue(self.data_phase, 0),
+            self.n_debug_in_progress.eq(1),
+            If(usb_core.data_recv_put,
+                If(usb_core.tok == PID.SETUP,
+                    If(usb_core.endp == 0,
+                        # If we get a SETUP packet with a "Vendor" type
+                        # going to this device, treat that as a DEBUG packet.
+                        cmd_ce.eq(1),
+                        byte_counter_reset.eq(1),
+                        If(usb_core.data_recv_payload[0:7] == magic_packet,
+                            NextState("RECEIVE_ADDRESS"),
+                        ).Else(
+                            # Wait for the end of the packet, to avoid
+                            # messing with normal USB operation
+                            NextState("WAIT_PKT_END"),
+                        ),
+                    )
+                )
+            )
+        )
+
+        # The target address comes as the wValue and wIndex in the SETUP
+        # packet.  Once we get that data, we're ready to do the operation.
+        fsm.act("RECEIVE_ADDRESS",
+            self.n_debug_in_progress.eq(0),
+            If(usb_core.data_recv_put,
+                byte_counter_ce.eq(1),
+                If((byte_counter >= 1),
+                    If((byte_counter <= 4),
+                        address_ce.eq(1),
+                    ).Elif((byte_counter <= 6),
+                        length_ce.eq(1),
+                    ).Elif(byte_counter == 9, # this is the final value during CRC, start prefetching now
+                        NextValue(prefetch_go, 1),
+                    )
+                ),
+            ),
+            # We don't need to explicitly ACK the SETUP packet, because
+            # they're always acknowledged implicitly.  Wait until the
+            # packet ends (i.e. until we've sent the ACK packet) before
+            # moving to the next state.
+            If(usb_core.end,
+                byte_counter_reset.eq(1),
+                If(cmd,
+                    send_to_wishbone.eq(1),
+                    NextState("READ_DATA"),
+                ).Else(
+                    NextState("RECEIVE_DATA"),
+                ),
+            ),
+        )
+
+        #################### WRITE MACHINE
+
+        fsm.act("RECEIVE_DATA",
+            # Set the "ACK" bit to 1, so we acknowledge the packet
+            # once it comes in, and so that we're in a position to
+            # receive data.
+            self.send_ack.eq(usb_core.endp == 0),
+            self.n_debug_in_progress.eq(0),
+            If(usb_core.endp == 0,
+                If(usb_core.data_recv_put,
+                    rx_data_ce.eq(1),
+                    If(burst_counter < 64,
+                       byte_counter_ce.eq(1),
+                    ),
+                    burst_counter_ce.eq(1),
+                    If((burst_counter <= 64) & ((burst_counter & 3) == 0) & (burst_counter != 0),
+                       address_inc.eq(1),
+                    ),
+                    If(byte_counter == (length - 1) | (((byte_counter & 0x3F) == 0x3F) & not_first_byte),
+                        NextState("WAIT_RECEIVE_DATA_END"),
+                    ).Elif(usb_core.end,
+                        self.write_fifo.we.eq(1),
+                        send_to_wishbone.eq(1),
+                        NextState("WRITE_DATA"),
+                    ).Elif((byte_counter & 3) == 3,
+                        self.write_fifo.we.eq(1),
+                        send_to_wishbone.eq(1),
+                    )
+                )
+            )
+        )
+        fsm.act("WAIT_RECEIVE_DATA_END",
+            self.n_debug_in_progress.eq(0),
+            self.send_ack.eq(1),
+            # Wait for the end of the USB packet, if
+            # it hasn't come already.
+            If(usb_core.end,
+                self.write_fifo.we.eq(1),
+                send_to_wishbone.eq(1),
+                NextState("WRITE_DATA")
+            )
+        )
+
+        fsm.act("WRITE_DATA",
+            self.n_debug_in_progress.eq(0),
+            transfer_active.eq(1),
+            If(reply_from_wishbone,
+                NextState("WAIT_SEND_ACK_START_WRITE"),
+            )
+        )
+
+        fsm.act("WAIT_SEND_ACK_START_WRITE",
+            self.n_debug_in_progress.eq(0),
+            If(usb_core.start,
+               NextState("SEND_ACK_WRITE")
+            ),
+        )
+
+        # Send the ACK.  If the endpoint number is incorrect, go back and
+        # wait again.
+        fsm.act("SEND_ACK_WRITE",
+            self.n_debug_in_progress.eq(0),
+            If(usb_core.endp != 0,
+                NextState("WAIT_SEND_ACK_START")
+            ),
+            self.send_ack.eq(usb_core.endp == 0),
+            If(usb_core.end,
+               If( byte_counter != length, 
+                   NextValue(not_first_byte, 0),
+                   NextValue(self.data_phase, ~self.data_phase),
+                   NextState("RECEIVE_DATA"),
+                ).Else(
+                   NextState("IDLE"),
+                )
+            ),
+        )
+
+        ############### READ MACHINE
+
+        fsm.act("READ_DATA",
+            self.n_debug_in_progress.eq(0),
+            transfer_active.eq(1),
+            If(reply_from_wishbone,
+                NextState("SEND_DATA_WAIT_START"),
+            )
+        )
+
+        fsm.act("SEND_DATA_WAIT_START",
+            self.n_debug_in_progress.eq(0),
+            If(usb_core.start,
+                NextState("SEND_DATA"),
+            ),
+        )
+        fsm.act("SEND_DATA_BURST_WAIT",
+            self.n_debug_in_progress.eq(0),
+            self.sink_valid.eq(usb_core.endp == 0),
+            If(reply_from_wishbone,
+               NextState("SEND_DATA"),
+            )
+        )
+        self.comb += \
+            chooser(rd_data, byte_counter[0:2], self.sink_data, n=4, reverse=False)
+        fsm.act("SEND_DATA",
+            self.n_debug_in_progress.eq(0),
+            If(usb_core.endp != 0,
+                NextState("SEND_DATA_WAIT_START"),
+            ),
+            # Keep sink_valid high during the packet, which indicates we have data
+            # to send.  This also causes an "ACK" to be transmitted.
+            self.sink_valid.eq(usb_core.endp == 0),
+            If(usb_core.data_send_get,
+                NextValue(not_first_byte, 1),
+                byte_counter_ce.eq(1),
+                If( ((byte_counter & 3) == 3) & ((byte_counter + 1) != length),
+                    send_to_wishbone.eq(1),
+                    self.read_fifo.re.eq(1), # advance the read fifo by one position
+                    address_inc.eq(1),
+                    NextState("SEND_DATA_BURST_WAIT"),
+                )
+            ),
+            If( (byte_counter == length) | (((byte_counter & 0x3F) == 0x00) & not_first_byte),
+                NextState("WAIT_SEND_ACK_START")
+            ),
+            If(usb_core.end,
+                NextState("WAIT_SEND_ACK_START")
+            )
+        )
+
+        # To validate the transaction was successful, the host will now
+        # send an "IN" request.  Acknowledge that by setting
+        # self.send_ack, without putting anything in self.sink_data.
+        fsm.act("WAIT_SEND_ACK_START",
+            self.n_debug_in_progress.eq(0),
+            If(usb_core.start,
+               NextState("SEND_ACK")
+            ),
+            If(usb_core.end & (byte_counter != length),
+               #byte_counter_ce.eq(1),
+               send_to_wishbone.eq(1),
+                #address_inc.eq(1),
+               NextValue(not_first_byte, 0),
+               NextValue(self.data_phase, ~self.data_phase),
+               NextState("READ_DATA"),
+            ),
+        )
+
+        # Send the ACK.  If the endpoint number is incorrect, go back and
+        # wait again.
+        fsm.act("SEND_ACK",
+            self.n_debug_in_progress.eq(0),
+            If(usb_core.endp != 0,
+                NextState("WAIT_SEND_ACK_START")
+            ),
+            # If(usb_core.retry,
+            #     If(cmd,
+            #         byte_counter_reset.eq(1),
+            #         NextState("SEND_DATA"),
+            #     ),
+            # ),
+            self.send_ack.eq(usb_core.endp == 0),
+            If(usb_core.end,
+                NextState("IDLE"),
+            )
+        )
+
+        fsm.act("WAIT_PKT_END",
+            self.n_debug_in_progress.eq(1),
+            If(usb_core.end,
+                NextState("IDLE"),
+            )
+        )

--- a/valentyusb/usbcore/cpu/usbwishboneburstbridge.py
+++ b/valentyusb/usbcore/cpu/usbwishboneburstbridge.py
@@ -398,7 +398,7 @@ class USBWishboneBurstBridge(Module, AutoDoc):
                NextState("SEND_DATA"),
             )
         )
-        self.comb += \
+        self.sync.usb_12 += \
             chooser(self.rd_data, byte_counter[0:2], self.sink_data, n=4, reverse=False)
         fsm.act("SEND_DATA",
             self.n_debug_in_progress.eq(0),

--- a/valentyusb/usbcore/cpu/usbwishboneburstbridge.py
+++ b/valentyusb/usbcore/cpu/usbwishboneburstbridge.py
@@ -288,7 +288,7 @@ class USBWishboneBurstBridge(Module, AutoDoc):
                     )
                 ),
             ),
-            If(byte_counter == 7, # length is stable, can start prefetching now
+            If(byte_counter == 8,
                 NextValue(prefetch_go, 1),
             ),
             # We don't need to explicitly ACK the SETUP packet, because

--- a/valentyusb/usbcore/cpu/usbwishboneburstbridge.py
+++ b/valentyusb/usbcore/cpu/usbwishboneburstbridge.py
@@ -119,8 +119,8 @@ class USBWishboneBurstBridge(Module, AutoDoc):
         self.length = length = Signal(16, reset_less=True)
         length_ce = Signal()
 
-        self.data = data = Signal(32, reset_less=True)
-        self.rd_data = rd_data = Signal(32, reset_less=True)
+        self.data = data = Signal(32)
+        self.rd_data = Signal(32)
         rx_data_ce = Signal()
 
         # wishbone_response = Signal(32, reset_less=True)
@@ -152,7 +152,7 @@ class USBWishboneBurstBridge(Module, AutoDoc):
         self.comb += [
             # clk12 domain
             self.write_fifo.din.eq(data),      # data coming from USB interface
-            rd_data.eq(self.read_fifo.dout),  # data going to USB interface
+            self.rd_data.eq(self.read_fifo.dout),  # data going to USB interface
             # sys domain
             self.read_fifo.din.eq(self.wishbone.dat_r),
             self.wishbone.dat_w.eq(self.write_fifo.dout),
@@ -399,7 +399,7 @@ class USBWishboneBurstBridge(Module, AutoDoc):
             )
         )
         self.comb += \
-            chooser(rd_data, byte_counter[0:2], self.sink_data, n=4, reverse=False)
+            chooser(self.rd_data, byte_counter[0:2], self.sink_data, n=4, reverse=False)
         fsm.act("SEND_DATA",
             self.n_debug_in_progress.eq(0),
             If(usb_core.endp != 0,

--- a/valentyusb/usbcore/cpu/usbwishboneburstbridge.py
+++ b/valentyusb/usbcore/cpu/usbwishboneburstbridge.py
@@ -288,7 +288,7 @@ class USBWishboneBurstBridge(Module, AutoDoc):
                     )
                 ),
             ),
-            If(byte_counter == 9, # this is the final value during CRC, start prefetching now
+            If(byte_counter == 7, # length is stable, can start prefetching now
                 NextValue(prefetch_go, 1),
             ),
             # We don't need to explicitly ACK the SETUP packet, because


### PR DESCRIPTION
Here's a patch that adds Burst support to the debug bridge. 

It creates a separate "burst" bridge version that is invoked by passing "burst=true" when creating the usb core.

This is done in part to allow smaller devices to use a smaller, more resource efficient core. 

