### PR TITLE
USB host (DFP) support

### DIFF
--- a/valentyusb/usbcore/cpu/simplehostusb.py
+++ b/valentyusb/usbcore/cpu/simplehostusb.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+
+from enum import IntEnum
+
+from migen import *
+from migen.genlib import fifo
+from migen.genlib.cdc import MultiReg, PulseSynchronizer, BusSynchronizer, BlindTransfer
+
+from litex.soc.integration.doc import AutoDoc, ModuleDoc
+from litex.soc.interconnect import stream
+from litex.soc.interconnect import csr_eventmanager as ev
+from litex.soc.interconnect.csr import CSRStorage, CSRStatus, CSRField, AutoCSR
+
+from litex.soc.cores.gpio import GPIOOut
+
+from ..endpoint import EndpointType, EndpointResponse
+from ..pid import PID, PIDTypes
+from ..sm.hosttransfer import UsbHostTransfer
+from ..rx.speed_detect import RxSpeedDetect
+
+"""
+Register Interface:
+
+"""
+
+class SimpleHostUsb(Module, AutoCSR, AutoDoc):
+    """
+    """
+
+    def __init__(self, iobuf, cdc=False):
+        # USB Core
+        self.submodules.usb_core = usb_core = UsbHostTransfer(iobuf, cdc=cdc)
+        self.iobuf = iobuf = usb_core.iobuf
+
+        ems = []
+
+        self.submodules.sof = sof = SOFHandler(usb_core, cdc=cdc)
+        ems.append(sof.ev)
+
+        self.submodules.transfer = transfer = TransferHandler(usb_core, cdc=cdc)
+        ems.append(transfer.ev)
+
+        self.submodules.speed_detect = speed_detect = SpeedDetector(usb_core, cdc=cdc)
+        ems.append(speed_detect.ev)
+
+        self.submodules.ev = ev.SharedIRQ(*ems)
+
+        self.reset = CSRStorage(
+            fields=[CSRField("reset", 1, description="Set to ``1`` to reset the USB bus.")])
+
+        if cdc:
+            self.specials += MultiReg(self.reset.fields.reset, self.usb_core.i_reset, odomain="usb_12")
+        else:
+            self.comb += self.crc_core.i_reset.eq(self.reset.fields.reset)
+
+        self.comb += [
+            transfer.data_out_advance.eq(usb_core.data_send_get),
+            usb_core.data_send_have.eq(transfer.data_out_have),
+            usb_core.data_send_payload.eq(transfer.data_out),
+            transfer.data_recv_payload.eq(usb_core.data_recv_payload),
+            transfer.data_recv_put.eq(usb_core.data_recv_put),
+        ]
+
+        self.comb += [
+            usb_core.i_frame.eq(sof.frame),
+            usb_core.i_sof.eq(sof.sof_pulse),
+            usb_core.i_addr.eq(transfer.command.addr),
+            usb_core.i_ep.eq(transfer.command.epno),
+            usb_core.i_cmd_setup.eq(transfer.command.setup),
+            usb_core.i_cmd_in.eq(getattr(transfer.command, 'in')),
+            usb_core.i_cmd_out.eq(transfer.command.out),
+            usb_core.i_cmd_pre.eq(transfer.command.pre),
+            usb_core.i_cmd_data1.eq(transfer.command.data1),
+            usb_core.i_cmd_iso.eq(transfer.command.iso),
+        ]
+
+class SOFHandler(Module, AutoCSR):
+
+    def __init__(self, usb_core, cdc=False):
+        self.frame = frame = Signal(11)
+        counter = Signal(max=12000)
+        self.sof_pulse = new_frame = Signal()
+        self.sync.usb_12 += [
+            If (counter == 11999,
+                counter.eq(0),
+                frame.eq(frame+1),
+                new_frame.eq(1)
+            ).Else(counter.eq(counter+1),
+                   new_frame.eq(0))
+        ]
+
+        self.frame_csr = CSRStatus(name="frame",
+            fields=[
+                CSRField("frame", 11, description="Current USB frame number"),
+            ])
+
+        self.submodules.ev = ev.EventManager()
+        self.ev.submodules.new_frame = ev.EventSourcePulse(name="new_frame")
+        self.ev.finalize()
+
+        if cdc:
+            self.submodules.frame_blind = blind = BlindTransfer("usb_12", "sys", 11)
+            self.comb += [
+                blind.i.eq(new_frame),
+                blind.data_i.eq(frame),
+                self.ev.new_frame.trigger.eq(blind.o),
+                self.frame_csr.fields.frame.eq(blind.data_o)
+            ]
+        else:
+            self.comb += [
+                self.ev.new_frame.trigger.eq(new_frame),
+                self.frame_csr.fields.frame.eq(frame)
+            ]
+
+
+class TransferHandler(Module, AutoCSR):
+
+    def __init__(self, usb_core, cdc=False):
+        if cdc:
+            self.submodules.write_data_buf = write_buf = ResetInserter(["usb_12", "sys"])(ClockDomainsRenamer({"write":"sys","read":"usb_12"})(fifo.AsyncFIFOBuffered(width=8, depth=64)))
+            self.submodules.read_data_buf = read_buf = ResetInserter(["usb_12", "sys"])(ClockDomainsRenamer({"write":"usb_12","read":"sys"})(fifo.AsyncFIFOBuffered(width=8, depth=128))) # 66
+        else:
+            self.submodules.write_data_buf = write_buf = ResetInserter()(fifo.SyncFIFOBuffered(width=8, depth=64))
+            self.submodules.read_data_buf = read_buf = ResetInserter()(fifo.SyncFIFOBuffered(width=8, depth=128)) # 66
+
+        self.data_out_fifo = CSRStorage(name="data_out",
+            fields=[
+                CSRField("data", 8, description="The next byte to add to the transmit FIFO."),
+            ],
+            description="""
+                Each byte written into this register gets added to an outgoing FIFO. Any
+                bytes that are written here will be transmitted in the order in which
+                they were added.  The FIFO queue is automatically advanced with each write.
+                The FIFO queue is 64 bytes deep.  If you exceed this amount, the result is undefined."""
+        )
+
+        self.data_in_fifo = CSRStatus(name="data_in",
+            fields=[
+                CSRField("data", 8, description="The top byte of the receive FIFO."),
+            ],
+            description="""
+                Data received from the device will go into a FIFO.  This register
+                reflects the contents of the top byte in that FIFO.  Reading from
+                this register advances the FIFO pointer."""
+        )
+
+        self.cmd = cmd = CSRStorage(
+            fields=[
+                CSRField("addr", 7, description="The device address for the transaction."),
+                CSRField("epno", 4, offset=8, description="The endpoint number for the transaction."),
+                CSRField("setup", offset=16, description="Write a ``1`` here to start a SETUP transfer."),
+                CSRField("in", description="Write a ``1`` here to start an IN transfer."),
+                CSRField("out", description="Write a ``1`` here to start an OUT transfer."),
+                CSRField("pre", description="Write a ``1`` here to send a PRE packet at the start of the transfer."),
+                CSRField("data1", description="Write a ``1`` here to use a ``DATA1`` token for data, ``0`` for ``DATA0``."),
+                CSRField("iso", description="Write a ``1`` here to skip handshake after data packet."),
+            ],
+            write_from_dev=True,
+            description="""
+                Starts transfers."""
+        )
+        cmd.dat_w.eq(cmd.storage & 0xffff) # Clear upper 16 bits on cmd_latched
+
+        self.command = Record([(f.name, f.size) for f in cmd.fields.fields])
+
+        self.status = CSRStatus(
+            fields=[
+                CSRField("have", description="``1`` if there is data in the receive FIFO."),
+            ],
+            description="""
+                Status."""
+        )
+
+        self.submodules.ev = ev.EventManager()
+        self.ev.submodules.got_ack = ev.EventSourcePulse(name="ack", description="Got an ``ACK`` packet")
+        self.ev.submodules.got_nak = ev.EventSourcePulse(name="nak", description="Got a ``NAK`` packet")
+        self.ev.submodules.got_stall = ev.EventSourcePulse(name="stall", description="Got a ``STALL`` packet")
+        self.ev.submodules.got_data0 = ev.EventSourcePulse(name="data0", description="Got a ``DATA0`` packet")
+        self.ev.submodules.got_data1 = ev.EventSourcePulse(name="data1", description="Got a ``DATA1`` packet")
+        self.ev.finalize()
+
+        self.data_out = Signal(8)
+        self.data_out_have = Signal()
+        self.data_out_advance = Signal()
+
+        self.data_recv_payload = Signal(8)
+        self.data_recv_put = Signal()
+
+        if cdc:
+            self.submodules.acksync = BlindTransfer('usb_12', 'sys')
+            self.submodules.naksync = BlindTransfer('usb_12', 'sys')
+            self.submodules.stallsync = BlindTransfer('usb_12', 'sys')
+            self.submodules.data0sync = BlindTransfer('usb_12', 'sys')
+            self.submodules.data1sync = BlindTransfer('usb_12', 'sys')
+            self.comb += [
+                self.acksync.i.eq(usb_core.o_got_ack),
+                self.ev.got_ack.trigger.eq(self.acksync.o),
+                self.naksync.i.eq(usb_core.o_got_nak),
+                self.ev.got_nak.trigger.eq(self.naksync.o),
+                self.stallsync.i.eq(usb_core.o_got_stall),
+                self.ev.got_stall.trigger.eq(self.stallsync.o),
+                self.data0sync.i.eq(usb_core.o_got_data0),
+                self.ev.got_data0.trigger.eq(self.data0sync.o),
+                self.data1sync.i.eq(usb_core.o_got_data1),
+                self.ev.got_data1.trigger.eq(self.data1sync.o),
+            ]
+
+            self.comb += [
+                self.data_out.eq(write_buf.dout),
+                write_buf.re.eq(self.data_out_advance),
+                self.data_out_have.eq(write_buf.readable),
+                read_buf.we.eq(self.data_recv_put),
+                read_buf.din.eq(self.data_recv_payload),
+            ]
+            self.comb += [
+                write_buf.we.eq(self.data_out_fifo.re),
+                write_buf.din.eq(self.data_out_fifo.storage),
+                self.status.fields.have.eq(read_buf.readable),
+                self.data_in_fifo.fields.data.eq(read_buf.dout),
+                read_buf.re.eq(self.data_in_fifo.we)
+            ]
+
+            self.submodules.cmd_latched_s = PulseSynchronizer('usb_12', 'sys')
+            self.comb += [
+                self.cmd_latched_s.i.eq(usb_core.o_cmd_latched),
+                cmd.we.eq(self.cmd_latched_s.o)
+            ]
+            self.submodules.cmd_s = BusSynchronizer(len(self.command), 'sys', 'usb_12')
+            command_sys = Record(self.command.layout)
+            self.comb += [
+                self.cmd_s.i.eq(command_sys.raw_bits()),
+                self.command.raw_bits().eq(self.cmd_s.o),
+            ]
+            self.comb += [
+                getattr(command_sys, f.name).eq(
+                    cmd.storage[f.offset:f.offset+f.size]
+                ) for f in cmd.fields.fields
+            ]
+        else:
+            self.comb += [
+                self.ev.got_ack.trigger.eq(usb_core.o_got_ack),
+                self.ev.got_nak.trigger.eq(usb_core.o_got_nak),
+                self.ev.got_stall.trigger.eq(usb_core.o_got_stall),
+                self.ev.got_data0.trigger.eq(usb_core.o_got_data0),
+                self.ev.got_data1.trigger.eq(usb_core.o_got_data1),
+            ]
+
+            self.comb += [
+                self.data_out.eq(write_buf.dout),
+                self.data_out_have.eq(write_buf.readable),
+                write_buf.re.eq(self.data_out_advance),
+                write_buf.we.eq(self.data_out_fifo.re),
+                write_buf.din.eq(self.data_out_fifo.storage),
+                self.status.fields.have.eq(read_buf.readable),
+                self.data_in_fifo.fields.data.eq(read_buf.dout),
+                read_buf.re.eq(self.data_in_fifo.we),
+                read_buf.we.eq(self.data_recv_put),
+                read_buf.din.eq(self.data_recv_payload),
+            ]
+
+            self.comb += cmd.we.eq(usb_core.o_cmd_latched)
+            self.comb += [
+                getattr(self.command, f.name).eq(
+                    cmd.storage[f.offset:f.offset+f.size]
+                ) for f in cmd.fields.fields
+            ]
+
+class SpeedDetector(Module, AutoCSR):
+
+    def __init__(self, usb_core, cdc=False):
+        speed_detect = RxSpeedDetect()
+        self.submodules.speed_detect = speed_detect = ClockDomainsRenamer("usb_48")(speed_detect)
+        ls_detect = Signal()
+        fs_detect = Signal()
+        self.speed = CSRStatus(
+            fields=[
+                CSRField("low_speed", 1, description="``1`` if a low speed device is detected"),
+                CSRField("full_speed", 1, description="``1`` if a full speed device is detected")
+            ])
+        self.specials += [
+            MultiReg(speed_detect.o_ls_detect, ls_detect),
+            MultiReg(speed_detect.o_fs_detect, fs_detect),
+        ]
+        self.comb += [
+            speed_detect.i_d_p.eq(usb_core.iobuf.usb_p_rx),
+            speed_detect.i_d_n.eq(usb_core.iobuf.usb_n_rx),
+            speed_detect.i_tx_en.eq(usb_core.tx.o_oe)
+        ]
+        self.sync += [
+            self.speed.fields.low_speed.eq(ls_detect),
+            self.speed.fields.full_speed.eq(fs_detect),
+        ]
+        self.submodules.ev = ev.EventManager()
+        self.ev.submodules.speed_change = ev.EventSourcePulse(name="speed_change")
+        self.ev.finalize()
+        self.comb += [
+            self.ev.speed_change.trigger.eq((self.speed.fields.low_speed ^ ls_detect) |
+                                            (self.speed.fields.full_speed ^ fs_detect))
+        ]

--- a/valentyusb/usbcore/io.py
+++ b/valentyusb/usbcore/io.py
@@ -19,6 +19,7 @@ class IoBuf(Module):
 
         self.usb_p_rx = Signal()
         self.usb_n_rx = Signal()
+        self.usb_ls_rx = Signal()
 
         self.usb_p_rx_io = Signal()
         self.usb_n_rx_io = Signal()
@@ -50,6 +51,9 @@ class IoBuf(Module):
             If(self.usb_tx_en,
                 self.usb_p_rx.eq(0b1),
                 self.usb_n_rx.eq(0b0),
+            ).Elif(self.usb_ls_rx,
+                self.usb_p_rx.eq(usb_n_t_i),
+                self.usb_n_rx.eq(usb_p_t_i),
             ).Else(
                 self.usb_p_rx.eq(usb_p_t_i),
                 self.usb_n_rx.eq(usb_n_t_i),

--- a/valentyusb/usbcore/rx/clock.py
+++ b/valentyusb/usbcore/rx/clock.py
@@ -52,7 +52,7 @@ class RxClockDataRecovery(Module):
         Represents SE1 on the incoming USB data pair.
         Qualify with line_state_valid.
     """
-    def __init__(self, usbp_raw, usbn_raw):
+    def __init__(self, usbp_raw, usbn_raw, low_speed=None):
         if False:
             #######################################################################
             # Synchronize raw USB signals
@@ -133,7 +133,7 @@ class RxClockDataRecovery(Module):
 
         # We 4x oversample, so make the line_state_phase have
         # 4 possible values.
-        line_state_phase = Signal(2)
+        line_state_phase = Signal(2 if low_speed is None else 5)
 
         self.line_state_valid = Signal()
         self.line_state_dj = Signal()
@@ -150,6 +150,10 @@ class RxClockDataRecovery(Module):
 
                 # make sure we never assert valid on a transition
                 self.line_state_valid.eq(0),
+            ).Elif(low_speed is not None and ~low_speed,
+                # keep tracking the clock by incrementing the phase
+		# (with a reduced period for full speed mode)
+                line_state_phase.eq((line_state_phase + 1) & 3),
             ).Else(
                 # keep tracking the clock by incrementing the phase
                 line_state_phase.eq(line_state_phase + 1)

--- a/valentyusb/usbcore/rx/pullup_detect.py
+++ b/valentyusb/usbcore/rx/pullup_detect.py
@@ -3,14 +3,14 @@ from migen import *
 from migen.fhdl.decorators import ResetInserter
 
 @ResetInserter()
-class RxSpeedDetect(Module):
+class RxPullUpDetect(Module):
 
     def __init__(self, threshold=1000):
         self.i_d_p = Signal()
         self.i_d_n = Signal()
         self.i_tx_en = Signal()
-        self.o_ls_detect = Signal()
-        self.o_fs_detect = Signal()
+        self.o_j_pullup_detect = Signal()
+        self.o_k_pullup_detect = Signal()
 
         cnt = Signal(max=threshold+1)
         pull_mode_cur = Signal(2)
@@ -18,8 +18,8 @@ class RxSpeedDetect(Module):
         pull_mode_latched = Signal(2)
 
         self.comb += [
-            self.o_fs_detect.eq(pull_mode_latched[0]),
-            self.o_ls_detect.eq(pull_mode_latched[1])
+            self.o_j_pullup_detect.eq(pull_mode_latched[0]),
+            self.o_k_pullup_detect.eq(pull_mode_latched[1])
         ]
 
         self.sync += [

--- a/valentyusb/usbcore/rx/speed_detect.py
+++ b/valentyusb/usbcore/rx/speed_detect.py
@@ -1,0 +1,37 @@
+from migen import *
+
+from migen.fhdl.decorators import ResetInserter
+
+@ResetInserter()
+class RxSpeedDetect(Module):
+
+    def __init__(self, threshold=1000):
+        self.i_d_p = Signal()
+        self.i_d_n = Signal()
+        self.i_tx_en = Signal()
+        self.o_ls_detect = Signal()
+        self.o_fs_detect = Signal()
+
+        cnt = Signal(max=threshold+1)
+        pull_mode_cur = Signal(2)
+        pull_mode_last = Signal(2)
+        pull_mode_latched = Signal(2)
+
+        self.comb += [
+            self.o_fs_detect.eq(pull_mode_latched[0]),
+            self.o_ls_detect.eq(pull_mode_latched[1])
+        ]
+
+        self.sync += [
+            pull_mode_last.eq(pull_mode_cur),
+            pull_mode_cur.eq(Cat(self.i_d_p, self.i_d_n)),
+            If (self.i_tx_en | (pull_mode_cur != pull_mode_last) |
+                (pull_mode_last == 0b11) |
+                ((pull_mode_last ^ pull_mode_latched) == 0b11),
+                cnt.eq(0)
+            ).Elif (cnt == threshold,
+                pull_mode_latched.eq(pull_mode_last)
+            ).Else (
+                cnt.eq(cnt + 1)
+            )
+        ]

--- a/valentyusb/usbcore/sm/hosttransfer.py
+++ b/valentyusb/usbcore/sm/hosttransfer.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+
+from migen import *
+from migen.genlib import fsm
+from migen.genlib.cdc import MultiReg
+
+from ..endpoint import EndpointType, EndpointResponse
+from ..pid import PID, PIDTypes
+from ..rx.speed_detect import RxSpeedDetect
+from ..rx.pipeline import RxPipeline
+from ..tx.pipeline import TxPipeline
+from ..sm.header import PacketHeaderDecode
+from ..sm.send import TxPacketSend
+
+class UsbHostTransfer(Module):
+
+    def __init__(self, iobuf, auto_crc=True, cdc=False):
+        self.submodules.iobuf = iobuf = ClockDomainsRenamer("usb_48")(iobuf)
+        if iobuf.usb_pullup is not None:
+            self.comb += iobuf.usb_pullup.eq(0)
+        self.submodules.tx = tx = TxPipeline()
+        self.submodules.txstate = txstate = TxPacketSend(tx, auto_crc=auto_crc, token_support=True)
+        self.submodules.rx = rx = RxPipeline()
+        self.submodules.rxstate = rxstate = PacketHeaderDecode(rx)
+        self.comb += [
+            tx.i_bit_strobe.eq(rx.o_bit_strobe),
+        ]
+
+        self.data_recv_put = Signal()
+        self.data_recv_payload = Signal(8)
+
+        self.data_send_get = Signal()
+        self.data_send_have = Signal()
+        self.data_send_payload = Signal(8)
+        self.data_end = Signal()
+
+        self.i_addr = Signal(7)
+        self.i_ep = Signal(4)
+        self.i_frame = Signal(11)
+        self.comb += [
+            txstate.i_addr.eq(self.i_addr),
+            txstate.i_ep.eq(self.i_ep),
+            txstate.i_frame.eq(self.i_frame)
+        ]
+
+        self.i_reset = Signal()
+        self.i_sof = Signal()
+
+        self.i_cmd_setup = Signal()
+        self.i_cmd_in = Signal()
+        self.i_cmd_out = Signal()
+        self.i_cmd_pre = Signal()
+        self.i_cmd_data1 = Signal()
+        self.i_cmd_iso = Signal()
+        self.o_cmd_latched = Signal()
+
+        self.o_got_ack = Signal()
+        self.o_got_nak = Signal()
+        self.o_got_stall = Signal()
+        self.o_got_data0 = Signal()
+        self.o_got_data1 = Signal()
+
+        cmd_data1 = Signal()
+        cmd_iso = Signal()
+        low_speed_override = Signal()
+        sof_latch = Signal()
+
+        reset_out = Signal()
+        self.specials += MultiReg(self.i_reset, reset_out, odomain="usb_48")
+
+        self.comb += [
+            rx.i_usbp.eq(iobuf.usb_p_rx),
+            rx.i_usbn.eq(iobuf.usb_n_rx),
+            iobuf.usb_tx_en.eq(tx.o_oe | reset_out),
+            iobuf.usb_p_tx.eq(tx.o_usbp & ~reset_out),
+            iobuf.usb_n_tx.eq(tx.o_usbn & ~reset_out),
+        ]
+
+        self.sync.usb_12 += If(self.i_sof, sof_latch.eq(1))
+
+        fsm = ResetInserter()(FSM(reset_state='IDLE'))
+        self.submodules.fsm = fsm = ClockDomainsRenamer('usb_12')(fsm)
+        self.comb += fsm.reset.eq(self.i_reset | rx.o_reset)
+
+        fsm.act('IDLE',
+                NextValue(low_speed_override, 0),
+                If (sof_latch,
+                   NextState('SOF')
+                ).Elif (self.i_cmd_setup | self.i_cmd_in | self.i_cmd_out,
+                   If (self.i_cmd_pre,
+                       NextState('PREAMBLE')
+                   ).Else (NextState('START_TRANSFER'))))
+
+        fsm.act('SOF',
+                txstate.i_pkt_start.eq(1),
+                txstate.i_pid.eq(PID.SOF),
+                If (txstate.o_pkt_end,
+                    NextValue(sof_latch, 0),
+                    NextState('IDLE')))
+
+        fsm.act('PREAMBLE',
+                txstate.i_pkt_start.eq(1),
+                txstate.i_pid.eq(PID.PRE),
+                If (txstate.o_pkt_end,
+                    NextValue(low_speed_override, 1),
+                    NextState('START_TRANSFER_AFTER_PREAMBLE')))
+
+        fsm.delayed_enter('START_TRANSFER_AFTER_PREAMBLE', 'START_TRANSFER', 4)
+
+        fsm.act('START_TRANSFER',
+                self.o_cmd_latched.eq(1),
+                NextValue(cmd_data1, self.i_cmd_data1),
+                NextValue(cmd_iso, self.i_cmd_iso),
+                If (self.i_cmd_setup,
+                        NextState('SETUP')
+                ).Elif (self.i_cmd_in,
+                        NextState('IN')
+                ).Elif (self.i_cmd_out,
+                        NextState('OUT')
+                ).Else (NextState('IDLE')))
+
+        fsm.act('SETUP',
+                txstate.i_pkt_start.eq(1),
+                txstate.i_pid.eq(PID.SETUP),
+                If (txstate.o_pkt_end,
+                    NextState('SEND_DATA')))
+
+        fsm.act('IN',
+                txstate.i_pkt_start.eq(1),
+                txstate.i_pid.eq(PID.IN),
+                If (txstate.o_pkt_end,
+                    NextState('WAIT_REPLY')))
+
+        fsm.act('OUT',
+                txstate.i_pkt_start.eq(1),
+                txstate.i_pid.eq(PID.OUT),
+                If (txstate.o_pkt_end,
+                    NextState('SEND_DATA')))
+
+        fsm.act('SEND_DATA',
+                txstate.i_pkt_start.eq(1),
+                txstate.i_pid.eq(Mux(cmd_data1, PID.DATA1, PID.DATA0)),
+                self.data_send_get.eq(txstate.o_data_ack),
+                self.data_end.eq(txstate.o_pkt_end),
+                If (txstate.o_pkt_end,
+                    If(cmd_iso,
+                       NextState('IDLE')
+                    ).Else(NextState('WAIT_REPLY'))))
+
+        fsm.act('WAIT_REPLY',
+                If (rxstate.o_decoded,
+                    If ((rxstate.o_pid & PIDTypes.TYPE_MASK) == PIDTypes.DATA,
+                        NextState('RECV_DATA')
+                    ).Else (NextState('IDLE'),
+                            self.o_got_ack.eq(rxstate.o_pid == PID.ACK),
+                            self.o_got_nak.eq(rxstate.o_pid == PID.NAK),
+                            self.o_got_stall.eq(rxstate.o_pid == PID.STALL))
+                ).Elif(self.i_cmd_setup | self.i_cmd_in | self.i_cmd_out,
+                       NextValue(low_speed_override, 0),
+                       If (self.i_cmd_pre,
+                           NextState('PREAMBLE')
+                       ).Else (NextState('START_TRANSFER'))))
+
+        fsm.act('RECV_DATA',
+                self.data_recv_put.eq(rx.o_data_strobe),
+                If(rx.o_pkt_end,
+                   # FIXME: Discard if CRC16 is incorrect
+                   self.o_got_data0.eq(rxstate.o_pid == PID.DATA0),
+                   self.o_got_data1.eq(rxstate.o_pid == PID.DATA1),
+                   If (cmd_iso,
+                      NextState('IDLE')
+                   ).Else (NextState('ACK'))))
+
+        fsm.act('ACK',
+                txstate.i_pkt_start.eq(1),
+                txstate.i_pid.eq(PID.ACK),
+                If (txstate.o_pkt_end,
+                    NextState('IDLE')))
+
+        self.comb += [
+            self.data_recv_payload.eq(rx.o_data_payload),
+            txstate.i_data_payload.eq(self.data_send_payload),
+            txstate.i_data_ready.eq(self.data_send_have),
+        ]

--- a/valentyusb/usbcore/sm/hosttransfer.py
+++ b/valentyusb/usbcore/sm/hosttransfer.py
@@ -6,7 +6,6 @@ from migen.genlib.cdc import MultiReg
 
 from ..endpoint import EndpointType, EndpointResponse
 from ..pid import PID, PIDTypes
-from ..rx.speed_detect import RxSpeedDetect
 from ..rx.pipeline import RxPipeline
 from ..tx.pipeline import TxPipeline
 from ..sm.header import PacketHeaderDecode

--- a/valentyusb/usbcore/tx/nrzi.py
+++ b/valentyusb/usbcore/tx/nrzi.py
@@ -35,9 +35,9 @@ class TxNRZIEncoder(Module):
     i_data : Signal(1)
         Data bit to be transmitted on USB. Qualified by o_valid.
 
-    i_se0 : Signal(1)
-        Overrides value of o_data when asserted and indicates that SE0 state
-        should be asserted on USB. Qualified by o_valid.
+    i_keepalive : Signal(1)
+        Send a keepalive signal consisting of two SE0 bits.
+        Qualified by o_valid.
 
     i_low_speed : Signal(1)
         Indicates that low speed encoding of J and K should be used.
@@ -59,6 +59,7 @@ class TxNRZIEncoder(Module):
         self.i_valid = Signal()
         self.i_oe = Signal()
         self.i_data = Signal()
+        self.i_keepalive = Signal()
         self.i_low_speed = Signal()
 
         # Simple state machine to perform NRZI encoding.
@@ -79,7 +80,9 @@ class TxNRZIEncoder(Module):
                     # first bit of sync always forces a transition, we idle
                     # in J so the first output bit is K.
                     NextState("DK")
-                )
+                ).Elif(self.i_keepalive,
+                    NextState("SE0A")
+		)
             )
         )
 

--- a/valentyusb/usbcore/tx/nrzi.py
+++ b/valentyusb/usbcore/tx/nrzi.py
@@ -39,6 +39,10 @@ class TxNRZIEncoder(Module):
         Overrides value of o_data when asserted and indicates that SE0 state
         should be asserted on USB. Qualified by o_valid.
 
+    i_low_speed : Signal(1)
+        Indicates that low speed encoding of J and K should be used.
+
+
     Output Ports
     ------------
     o_usbp : Signal(1)
@@ -55,6 +59,7 @@ class TxNRZIEncoder(Module):
         self.i_valid = Signal()
         self.i_oe = Signal()
         self.i_data = Signal()
+        self.i_low_speed = Signal()
 
         # Simple state machine to perform NRZI encoding.
         self.submodules.nrzi = nrzi = FSM()
@@ -151,6 +156,6 @@ class TxNRZIEncoder(Module):
 
         self.sync += [
             self.o_oe.eq(oe),
-            self.o_usbp.eq(usbp),
-            self.o_usbn.eq(usbn),
+            self.o_usbp.eq(Mux(self.i_low_speed, usbn, usbp)),
+            self.o_usbn.eq(Mux(self.i_low_speed, usbp, usbn)),
         ]

--- a/valentyusb/usbcore/tx/pipeline.py
+++ b/valentyusb/usbcore/tx/pipeline.py
@@ -14,7 +14,7 @@ from ..test.common import BaseUsbTestCase
 
 
 class TxPipeline(Module):
-    def __init__(self):
+    def __init__(self, low_speed_support=False):
         self.i_bit_strobe = Signal()
 
         self.i_data_payload = Signal(8)
@@ -22,17 +22,20 @@ class TxPipeline(Module):
 
         self.i_oe = Signal()
 
+        if low_speed_support:
+            self.i_low_speed = Signal()
+
         self.o_usbp = Signal()
         self.o_usbn = Signal()
         self.o_oe = Signal()
 
         self.o_pkt_end = Signal()
 
-        tx_pipeline_fsm = FSM()
+        tx_pipeline_fsm = CEInserter()(FSM())
         self.submodules.tx_pipeline_fsm = ClockDomainsRenamer("usb_12")(tx_pipeline_fsm)
         shifter = TxShifter(width=8)
         self.submodules.shifter = ClockDomainsRenamer("usb_12")(shifter)
-        bitstuff = TxBitstuffer()
+        bitstuff = CEInserter()(TxBitstuffer())
         self.submodules.bitstuff = ClockDomainsRenamer("usb_12")(bitstuff)
         nrzi = TxNRZIEncoder()
         self.submodules.nrzi = ClockDomainsRenamer("usb_48")(nrzi)
@@ -57,21 +60,35 @@ class TxPipeline(Module):
         da_stalled_reset = Signal()
         bitstuff_valid_data = Signal()
 
+        if low_speed_support:
+            new_bit = Signal()
+            bit_strobe_sync = cdc.PulseSynchronizer('usb_48', 'usb_12')
+            self.submodules += bit_strobe_sync
+            self.comb += [
+                bit_strobe_sync.i.eq(self.i_bit_strobe),
+                new_bit.eq(Mux(self.i_low_speed, bit_strobe_sync.o, 1))
+            ]
+        else:
+            new_bit = C(0b1)
+
         # Keep a Gray counter around to smoothly transition between states
         state_gray = Signal(2)
         state_data = Signal()
         state_sync = Signal()
 
         self.comb += [
+            tx_pipeline_fsm.ce.eq(new_bit),
+
             shifter.i_data.eq(self.i_data_payload),
             # Send a data strobe when we're two bits from the end of the sync pulse.
             # This is because the pipeline takes two bit times, and we want to ensure the pipeline
             # has spooled up enough by the time we're there.
 
             shifter.reset.eq(da_reset_shifter | sp_reset_shifter),
-            shifter.ce.eq(~stall),
+            shifter.ce.eq(new_bit & ~stall),
 
             bitstuff.reset.eq(da_reset_bitstuff),
+            bitstuff.ce.eq(new_bit),
             bitstuff.i_data.eq(shifter.o_data),
             stall.eq(bitstuff.o_stall),
 
@@ -89,7 +106,7 @@ class TxPipeline(Module):
 
             fit_oe.eq(state_data | state_sync),
             fit_dat.eq((state_data & shifter.o_data & ~bitstuff.o_stall) | sp_bit),
-            self.o_data_strobe.eq((state_data & shifter.o_get & ~stall & self.i_oe) | sp_o_data_strobe),
+            self.o_data_strobe.eq(((state_data & shifter.o_get & ~stall & self.i_oe) | sp_o_data_strobe) & new_bit),
         ]
 
         # If we reset the shifter, then o_empty will go high on the next cycle.
@@ -101,7 +118,8 @@ class TxPipeline(Module):
             # da_reset_shifter.eq(~stall & shifter.o_empty & ~da_stalled_reset),
             # da_stalled_reset.eq(da_reset_shifter),
             # da_reset_bitstuff.eq(~stall & da_reset_shifter),
-            bitstuff_valid_data.eq(~stall & shifter.o_get & self.i_oe),
+            If(new_bit,
+               bitstuff_valid_data.eq(~stall & shifter.o_get & self.i_oe)),
         ]
 
         tx_pipeline_fsm.act('IDLE',
@@ -151,6 +169,9 @@ class TxPipeline(Module):
         cdc_dat = cdc.MultiReg(fit_dat, nrzi_dat, odomain="usb_48", n=3)
         cdc_oe  = cdc.MultiReg(fit_oe, nrzi_oe, odomain="usb_48", n=3)
         self.specials += [cdc_dat, cdc_oe]
+        if low_speed_support:
+            cdc_low_speed = cdc.MultiReg(self.i_low_speed, nrzi.i_low_speed, odomain="usb_48", n=3)
+            self.specials += cdc_low_speed
 
         self.comb += [
             nrzi.i_valid.eq(self.i_bit_strobe),

--- a/valentyusb/usbcore/tx/pipeline.py
+++ b/valentyusb/usbcore/tx/pipeline.py
@@ -24,6 +24,7 @@ class TxPipeline(Module):
 
         if low_speed_support:
             self.i_low_speed = Signal()
+            self.i_keepalive = Signal()
 
         self.o_usbp = Signal()
         self.o_usbn = Signal()
@@ -171,7 +172,8 @@ class TxPipeline(Module):
         self.specials += [cdc_dat, cdc_oe]
         if low_speed_support:
             cdc_low_speed = cdc.MultiReg(self.i_low_speed, nrzi.i_low_speed, odomain="usb_48", n=3)
-            self.specials += cdc_low_speed
+            cdc_keepalive = cdc.MultiReg(self.i_keepalive, nrzi.i_keepalive, odomain="usb_48", n=3)
+            self.specials += [cdc_low_speed, cdc_keepalive]
 
         self.comb += [
             nrzi.i_valid.eq(self.i_bit_strobe),


### PR DESCRIPTION
This set of commits add (optional) support for host mode, allowing both full-speed and low-speed peripherals to be connected using an OTG cable.  Any special handling of VBUS needs to be taken care of elsewhere, it is not within the scope of these changes.

Software support is here: zeldin/tinyusb@93319afa003876f3a7c9be3ca2d39eb3edd76930

Tested on an ECP5 FPGA with two gamepads, one full-speed and one low-speed.

Note that the CPU interface is basically the simplest one possible; there is no scheduling except of SOF/KA and any retransmissions after NAK or transmission error need to be handled manually in software.  Transfers larger than max packet size also have to be manually fragmented.  Making a UHCI/OHCI compliant interface should be possible, but would require more work.